### PR TITLE
Move testCase schema to a file and implement the agreed changes

### DIFF
--- a/schemas/testCase.xsd
+++ b/schemas/testCase.xsd
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <xs:element name="testCase">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="id"/>
+        <xs:element ref="references"/>
+        <xs:element ref="description"/>
+        <xs:element ref="dependencies"/>
+        <xs:element ref="rules"/>
+      </xs:sequence>
+      <xs:attribute name="testable" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="FALSE"/>
+            <xs:enumeration value="TRUE"/>
+            <xs:enumeration value="UNKNOWN"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="id">
+    <xs:complexType>
+      <xs:attribute name="requirementId" use="required" type="xs:NCName"/>
+      <xs:attribute name="specification" use="required"/>
+      <xs:attribute name="version" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="references">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="reference"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="reference">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              reference (element text): Requirement text copied from the specification.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:attribute name="requirementId" use="required" type="xs:NCName">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                @requirementId: Short ID of the requirement, as defined in the specification, e.g. CSIP1, CSIPSTR5.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="URL" use="required" type="xs:anyURI">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                @URL: Direct URL to the requirement text in the specification.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dependencies">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="dependency" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="dependency">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              dependency (element text): Description of the dependency.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:attribute name="requirementId" use="required" type="xs:NCName">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                @requirementId: Short ID of the requirement, as defined in the specification, e.g. CSIP1, CSIPSTR5.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="URL" use="required" type="xs:anyURI">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                @URL: Direct URL to the requirement text in the specification.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>  
+
+  <xs:element name="rules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="rule"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rule">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="description"/>
+        <xs:element ref="error"/>
+        <xs:element ref="corpusPackages"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:integer"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="error">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="message"/>
+      </xs:sequence>
+      <xs:attribute name="level" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="ERROR"/>
+            <xs:enumeration value="WARNING"/>
+            <xs:enumeration value="INFO"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="message" type="xs:string"/>
+  <xs:element name="corpusPackages">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="package" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="package">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="path"/>
+        <xs:element ref="description"/>
+      </xs:sequence>
+      <xs:attribute name="isValid" use="required" type="xs:NCName"/>
+      <xs:attribute name="name" use="required" type="xs:NCName"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="path" type="xs:string"/>
+  <xs:element name="description" type="xs:string"/>
+</xs:schema>


### PR DESCRIPTION
The schema should now be exactly as we agreed on 2019-03-07, i.e. everything from #72 plus the new value "UNKNOWN" to attribute "testCase/testable".

I updated the testCase.xml for CSIP1 "mets/OBJID" to be compliant with the schema:
https://github.com/DILCISBoard/eark-ip-test-corpus/blob/2884aff27799808fe39c76be7aa71f011b9a7000/corpus/mets-xml/mets/OBJID/testCase.xml 

The schema and the testCase validated properly at www.xmlvalidation.com.