### PR TITLE
testCase.xsd - split requirementText into child elements

### DIFF
--- a/schema/testCase.xsd
+++ b/schema/testCase.xsd
@@ -34,7 +34,7 @@
   <xs:element name="references">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="reference"/>
+        <xs:element ref="reference" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/schema/testCase.xsd
+++ b/schema/testCase.xsd
@@ -66,37 +66,33 @@
     </xs:complexType>
   </xs:element>
 
-
-<xs:element name="requirementText">
-  <xs:complexType mixed="true">
-    <xs:sequence>
-      <xs:element name="nameAndLocation" type="xs:string" minOccurs="0"/>
-      <xs:element name="description" type="xs:string" minOccurs="0"/>
-      <xs:element name="cardinality" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="0..1"/>
-            <xs:enumeration value="0..n"/>
-            <xs:enumeration value="1..1"/>
-            <xs:enumeration value="1..n"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-      <xs:element name="level" minOccurs="0">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="MUST"/>
-            <xs:enumeration value="SHOULD"/>
-            <xs:enumeration value="MAY"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-</xs:element>
-
-
-
+  <xs:element name="requirementText">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element name="nameAndLocation" type="xs:string" minOccurs="0"/>
+        <xs:element name="description" type="xs:string" minOccurs="0"/>
+        <xs:element name="cardinality" minOccurs="0">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="0..1"/>
+              <xs:enumeration value="0..n"/>
+              <xs:enumeration value="1..1"/>
+              <xs:enumeration value="1..n"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="level" minOccurs="0">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="MUST"/>
+              <xs:enumeration value="SHOULD"/>
+              <xs:enumeration value="MAY"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 
   <xs:element name="dependencies">
     <xs:complexType>

--- a/schema/testCase.xsd
+++ b/schema/testCase.xsd
@@ -6,7 +6,7 @@
       <xs:sequence>
         <xs:element ref="id"/>
         <xs:element ref="references"/>
-        <xs:element name="requirementText" type="xs:string"/>
+        <xs:element ref="requirementText"/>
         <xs:element ref="description"/>
         <xs:element ref="dependencies"/>
         <xs:element ref="rules"/>
@@ -65,6 +65,38 @@
       </xs:simpleContent>
     </xs:complexType>
   </xs:element>
+
+
+<xs:element name="requirementText">
+  <xs:complexType mixed="true">
+    <xs:sequence>
+      <xs:element name="nameAndLocation" type="xs:string" minOccurs="0"/>
+      <xs:element name="description" type="xs:string" minOccurs="0"/>
+      <xs:element name="cardinality" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="0..1"/>
+            <xs:enumeration value="0..n"/>
+            <xs:enumeration value="1..1"/>
+            <xs:enumeration value="1..n"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+      <xs:element name="level" minOccurs="0">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="MUST"/>
+            <xs:enumeration value="SHOULD"/>
+            <xs:enumeration value="MAY"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:element>
+
+
+
 
   <xs:element name="dependencies">
     <xs:complexType>


### PR DESCRIPTION
I saw two options to split the contents of `requirementText` while maintaining backward compatibility with testCase.xml files that have the whole requirement text as one chunk in the text content of `requirementText`:
- Option A: using children for everything
- Option B: using attributes for everything except description.

All things considered, I went for Option A. I'll explain the reasoning using CSIP17 as an example.

## Old schema
```xml
<requirementText>ID	Name and Location	Description and usage	Cardinality and Level
  CSIP17	Descriptive metadata 
  dmdSec	Must be used if descriptive metadata for the package content is available. Each descriptive metadata section (dmdSec) contains one description and thus is repeated when more descriptions are available. 
  It is possible to transfer metadata in a package using just the descriptive metadata section/or adminstrative metadata section.	0..n 
  SHOULD
</requirementText>
```

## Option A - Children
- All children are declared optional to account for structural rules (these are currently presented as unstructured text)
- `complexType mixed="true"` to allow text content (for backward compatibility)
- Usage will be:
  1) Each piece of info in its child element, nothing in the text content of `requirementText`; or
  2) The whole requirement in the text content of `requirementText`, no children present (i.e. exactly as with the old schema).

Future testCase.xml should be:
```xml
<requirementText>
  <nameAndLocation>
    Descriptive metadata
    `dmdSec`
  </nameAndLocation>
  <description>
    Must be used if descriptive metadata for the package content is available. Each descriptive metadata section (dmdSec) contains one description and thus is repeated when more descriptions are available. 
    It is possible to transfer metadata in a package using just the descriptive metadata section/or adminstrative metadata section.
  </description>
  <cardinality>0..n</cardinality>
  <level>SHOULD</level>
</requirementText>
```

## Option B - Attributes
- Description as text, everything else as attributes
- Compatibility automatic, but the use case with everything as one chunk will be semantically incorrect as the new model assumes only the "Description & usage" part goes into the text content of `requirementText`
- A disadvantage is that no multiline text is allowed in attributes, which would be nice for `nameAndLocation`.

Future testCase.xml under Option B:
```xml
<requirementText nameAndLocation="Descriptive metadata `dmdSec`" cardinality="0..n" level="SHOULD">
  Must be used if descriptive metadata for the package content is available. Each descriptive metadata section (dmdSec) contains one description and thus is repeated when more descriptions are available. 
  It is possible to transfer metadata in a package using just the descriptive metadata section/or adminstrative metadata section.
</requirementText>
```