### PR TITLE
CSIP37 testCase.xml

### DIFF
--- a/corpora/csip/metadata/amdsec/CSIP37/testCase.xml
+++ b/corpora/csip/metadata/amdsec/CSIP37/testCase.xml
@@ -1,9 +1,9 @@
 <!-- Root element for an individual test case, allows these to be wrapped into
 XML lists -->
 <testCase xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="testCase.xsd"
-  testable="UNKNOWN">
+  testable="TRUE">
   <!-- Unique ID for the test case -->
-  <id specification="E-ARK CSIP" version="2.0-DRAFT" requirementId="CSIP37"/>
+  <id specification="E-ARK CSIP" version="2.0.4" requirementId="CSIP37"/>
   <!-- URL references to requirements for convenient lookup -->
   <references>
     <reference requirementId="CSIP37" URL="http://earkcsip.dilcis.eu/#CSIP37"/>
@@ -12,12 +12,28 @@ XML lists -->
   <requirementText>Attribute used with the value “simple”. Value list is maintained by the xlink standard
 </requirementText>
   <!-- Textual description of the test case, extra notes beyond the requirment text. -->
-  <description></description>
+  <description>This is 1:1 with the METS requirement. Any value other than "simple" will break the xml according to the METS schema </description>
   <!-- List of requirments that this test case depends on in addition to the
   main requirememt, e.g. general requirments on the form of IDs -->
   <dependencies>
   </dependencies>
   <!-- A list of the validation rules derived from the test case -->
   <rules>
+    <rule id="1">
+      <description>Value has to be "simple"</description>
+      <error level="ERROR">
+        <message>The value has to be: "simple"</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="wrong_value_xlink_type">
+          <path>invalid/wrong_value_xlink_type</path>
+          <description>IP has the value "METS"</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP_with_schemas">
+          <path>valid/minimal_IP_with_schemas</path>
+          <description></description>
+        </package>
+      </corpusPackages>
+    </rule>
   </rules>
 </testCase>


### PR DESCRIPTION
This testCase is one of the cases where the CSIP requirement is identical with the requirement in the METS schema.
I have created a rule and two packages nonetheless.