### PR TITLE
CSIP52 testCase.xml

### DIFF
--- a/corpora/csip/metadata/amdsec/CSIP52/testCase.xml
+++ b/corpora/csip/metadata/amdsec/CSIP52/testCase.xml
@@ -1,9 +1,9 @@
 <!-- Root element for an individual test case, allows these to be wrapped into
 XML lists -->
 <testCase xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="testCase.xsd"
-  testable="UNKNOWN">
+  testable="TRUE">
   <!-- Unique ID for the test case -->
-  <id specification="E-ARK CSIP" version="2.0-DRAFT" requirementId="CSIP52"/>
+  <id specification="E-ARK CSIP" version="2.0.4" requirementId="CSIP52"/>
   <!-- URL references to requirements for convenient lookup -->
   <references>
     <reference requirementId="CSIP52" URL="http://earkcsip.dilcis.eu/#CSIP52"/>
@@ -12,12 +12,45 @@ XML lists -->
   <requirementText>Specifies the type of metadata in the linked file. Value is taken from the list provided by the standard.
 </requirementText>
   <!-- Textual description of the test case, extra notes beyond the requirment text. -->
-  <description></description>
+  <description>MDTYPE is mandatory according to the METS.xsd. And the allowed values are defined in the schema. So this requirement is identical to the requirement in the METS schema.
+    But I have created rules and packages nonetheless</description>
   <!-- List of requirments that this test case depends on in addition to the
   main requirememt, e.g. general requirments on the form of IDs -->
   <dependencies>
   </dependencies>
   <!-- A list of the validation rules derived from the test case -->
   <rules>
+    <rule id="1">
+      <description>The MDTYPE attribute must exist</description>
+      <error level="ERROR">
+        <message>The MDTYPE attribute must exist</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="mdRef_missing_MDTYPE">
+          <path>invalid/mdRef_missing_MDTYPE</path>
+          <description>The MDTYPE attribute is missing</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP_with_schemas">
+          <path>valid/minimal_IP_with_schemas</path>
+          <description>Minimal IP</description>
+        </package>
+      </corpusPackages>
+    </rule>
+    <rule id="2">
+      <description>The value in the MDTYPE attribute must be a valid value according to the schema</description>
+      <error level="ERROR">
+        <message>The value in the MDTYPE attribute must be a valid value according to the schema</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="mdRef_wrong_MDTYPE_value">
+          <path>invalid/mdRef_wrong_MDTYPE_value</path>
+          <description>The value in the MDTYPE attribute is E-ARK</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP_with_schemas">
+          <path>valid/minimal_IP_with_schemas</path>
+          <description>Minimal IP</description>
+        </package>
+      </corpusPackages>
+    </rule>
   </rules>
 </testCase>


### PR DESCRIPTION
MDTYPE is mandatory according to the METS.xsd. And the allowed values are defined in the schema. So this requirement is identical to the requirement in the METS schema.
But I have created rules and packages nonetheless