### PR TITLE
CSIP90 testCase.xml

### DIFF
--- a/corpora/csip/metadata/structmap/CSIP90/testCase.xml
+++ b/corpora/csip/metadata/structmap/CSIP90/testCase.xml
@@ -1,23 +1,59 @@
 <!-- Root element for an individual test case, allows these to be wrapped into
 XML lists -->
 <testCase xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="testCase.xsd"
-  testable="UNKNOWN">
+  testable="TRUE">
   <!-- Unique ID for the test case -->
-  <id specification="E-ARK CSIP" version="2.0-DRAFT" requirementId="CSIP90"/>
+  <id specification="E-ARK CSIP" version="2.0.4" requirementId="CSIP90"/>
   <!-- URL references to requirements for convenient lookup -->
   <references>
     <reference requirementId="CSIP90" URL="http://earkcsip.dilcis.eu/#CSIP90"/>
   </references>
   <!-- The full text of the requirement. -->
-  <requirementText>The metadata division (div) element in the package uses the value "Metadata" as the value for the attribute LABEL.
-</requirementText>
+  <requirementText>Metadata division label
+    mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Metadata']
+    The metadata division div element’s @LABEL attribute value must be “Metadata”.
+      See also: File group names
+  </requirementText>
   <!-- Textual description of the test case, extra notes beyond the requirment text. -->
-  <description></description>
+  <description>The CSIP90 is identical with the CSIP88. This testcase's rules are therefore identical with the ones in CSIP88</description>
   <!-- List of requirments that this test case depends on in addition to the
   main requirememt, e.g. general requirments on the form of IDs -->
   <dependencies>
+    <dependency requirementId="CSIP88" URL="http://earkcsip.dilcis.eu/#CSIP88"></dependency>
   </dependencies>
   <!-- A list of the validation rules derived from the test case -->
   <rules>
+    <rule id="1">
+      <description>There MUST be a div-element with the @LABEL='Metadata' nested in the div-element with the @LABEL='CSIP'</description>
+      <error level="ERROR">
+        <message>There MUST be a div-element with the @LABEL='Metadata' nested in the div-element with the @LABEL='CSIP'</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="no_div_label_metadata">
+          <path>invalid\no_div_label_metadata</path>
+          <description>There is no div-element with the @LABEL='Metadata' nested in the div-element with the @LABEL='CSIP'</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP">
+          <path>valid\minimal_IP</path>
+          <description>Minimal IP</description>
+        </package>
+      </corpusPackages>
+    </rule>
+    <rule id="2">
+      <description>There MUST be only one div-element with the @LABEL='Metadata' nested in the div-element with the @LABEL='CSIP'</description>
+      <error level="ERROR">
+        <message>There MUST be only one div-element with the @LABEL='Metadata' nested in the div-element with the @LABEL='CSIP'</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="two_div_elements_with_label_metadata">
+          <path>invalid\two_div_elements_with_label_metadata</path>
+          <description>Package with two div-elements with @LABEL='metadata'</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP">
+          <path>valid\minimal_IP</path>
+          <description>Minimal IP</description>
+        </package>
+      </corpusPackages>
+    </rule>
   </rules>
 </testCase>


### PR DESCRIPTION
CSIP90 is identical with CSIP88. This testcase's rules are therefore identical with the ones in CSIP88. 
Reported to A2 here: https://github.com/DILCISBoard/E-ARK-CSIP/issues/570 