### PR TITLE
CSIP95 testCase.xml

### DIFF
--- a/corpora/csip/metadata/structmap/CSIP95/testCase.xml
+++ b/corpora/csip/metadata/structmap/CSIP95/testCase.xml
@@ -1,23 +1,59 @@
 <!-- Root element for an individual test case, allows these to be wrapped into
 XML lists -->
 <testCase xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="testCase.xsd"
-  testable="UNKNOWN">
+  testable="TRUE">
   <!-- Unique ID for the test case -->
-  <id specification="E-ARK CSIP" version="2.0-DRAFT" requirementId="CSIP95"/>
+  <id specification="E-ARK CSIP" version="2.0.4" requirementId="CSIP95"/>
   <!-- URL references to requirements for convenient lookup -->
   <references>
     <reference requirementId="CSIP95" URL="http://earkcsip.dilcis.eu/#CSIP95"/>
   </references>
   <!-- The full text of the requirement. -->
-  <requirementText>The documentation division (div) element in the package uses the value "Documentation" as the value for the attribute LABEL.
+  <requirementText>Documentation division label
+    mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']
+    The documentation division div element in the package uses the value “Documentation” from the vocabulary as the value for the @LABEL attribute.
+      See also: File group names
 </requirementText>
   <!-- Textual description of the test case, extra notes beyond the requirment text. -->
-  <description></description>
+  <description>The CSIP95 is identical with the CSIP93. This testcase's rules are therefore identical with the ones in CSIP93</description>
   <!-- List of requirments that this test case depends on in addition to the
   main requirememt, e.g. general requirments on the form of IDs -->
   <dependencies>
+    <dependency requirementId="CSIP93" URL="http://earkcsip.dilcis.eu/#CSIP93"></dependency>
   </dependencies>
   <!-- A list of the validation rules derived from the test case -->
   <rules>
+    <rule id="1">
+      <description>There MUST be a div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</description>
+      <error level="ERROR">
+        <message>There MUST be a div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="no_div_label_Documentation">
+          <path>invalid\no_div_label_Documentation</path>
+          <description>There is no div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP">
+          <path>valid\minimal_IP</path>
+          <description>Minimal IP</description>
+        </package>
+      </corpusPackages>
+    </rule>
+    <rule id="2">
+      <description>There MUST be only one div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</description>
+      <error level="ERROR">
+        <message>There MUST be only one div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="two_div_elements_with_label_Documentation">
+          <path>invalid\two_div_elements_with_label_Documentation</path>
+          <description>Package with two div-elements with @LABEL='Documentation'</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP">
+          <path>valid\minimal_IP</path>
+          <description>Minimal IP</description>
+        </package>
+      </corpusPackages>
+    </rule>
   </rules>
 </testCase>

--- a/corpora/csip/metadata/structmap/CSIP95/testCase.xml
+++ b/corpora/csip/metadata/structmap/CSIP95/testCase.xml
@@ -1,56 +1,52 @@
-<!-- Root element for an individual test case, allows these to be wrapped into
-XML lists -->
 <testCase xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="testCase.xsd"
-  testable="TRUE">
-  <!-- Unique ID for the test case -->
-  <id specification="E-ARK CSIP" version="2.0.4" requirementId="CSIP95"/>
-  <!-- URL references to requirements for convenient lookup -->
-  <references>
+  testable="FALSE">
+    <id specification="E-ARK CSIP" version="2.0.4" requirementId="CSIP95"/>
+    <references>
     <reference requirementId="CSIP95" URL="http://earkcsip.dilcis.eu/#CSIP95"/>
   </references>
-  <!-- The full text of the requirement. -->
-  <requirementText>Documentation division label
-    mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']
-    The documentation division div element in the package uses the value “Documentation” from the vocabulary as the value for the @LABEL attribute.
+  <requirementText>
+    <name>Documentation division label</name>
+    <location>mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']</location>
+    <description>
+      The documentation division div element in the package uses the value "Documentation" from the vocabulary as the value for the @LABEL attribute.
       See also: File group names
-</requirementText>
-  <!-- Textual description of the test case, extra notes beyond the requirment text. -->
-  <description>The CSIP95 is identical with the CSIP93. This testcase's rules are therefore identical with the ones in CSIP93</description>
-  <!-- List of requirments that this test case depends on in addition to the
-  main requirememt, e.g. general requirments on the form of IDs -->
+    </description>
+    <cardinality>1..1</cardinality>
+    <level>MUST</level>
+  </requirementText>
+  <description>
+    CSIP95 seems identical with CSIP93, but the authors of the specification
+    had a distinction in mind: "… the first requirement defines whether the
+    division itself is mandatory, the second defines the required label
+    value," see the issue "Redundancies and incompatible priority levels" at
+    https://github.com/DILCISBoard/E-ARK-CSIP/issues/570. The cases of there
+    being no documentation division or more than one documentation division
+    are handled in CSIP93. Consequently, there is only one rule left for
+    CSIP95:
+      If the documentation division exists, it MUST have @LABEL='Documentation'.
+
+    This however is not reliably testable with algorithms of reasonable
+    complexity. Detecting a documentation division that is not marked
+    @LABEL='Documentation' would require analysing indirect indicators (e.g. a
+    structMap/div with references to files in /documentation folder), but
+    these cannot give enough confidence to announce a violation of a MUST
+    rule.
+
+    In sum, only valid IPs are meaningful for CSIP95 and the requirement is
+    effectively not testable.
+  </description>
   <dependencies>
     <dependency requirementId="CSIP93" URL="http://earkcsip.dilcis.eu/#CSIP93"></dependency>
   </dependencies>
-  <!-- A list of the validation rules derived from the test case -->
   <rules>
     <rule id="1">
-      <description>There MUST be a div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</description>
+      <description>If the documentation division exists, it MUST have @LABEL='Documentation'.</description>
       <error level="ERROR">
-        <message>There MUST be a div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</message>
+        <message>If the documentation division exists, it MUST have @LABEL='Documentation'.</message>
       </error>
       <corpusPackages>
-        <package isValid="FALSE" name="no_div_label_Documentation">
-          <path>invalid\no_div_label_Documentation</path>
-          <description>There is no div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</description>
-        </package>
-        <package isValid="TRUE" name="minimal_IP">
-          <path>valid\minimal_IP</path>
-          <description>Minimal IP</description>
-        </package>
-      </corpusPackages>
-    </rule>
-    <rule id="2">
-      <description>There MUST be only one div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</description>
-      <error level="ERROR">
-        <message>There MUST be only one div-element with the @LABEL='Documentation' nested in the div-element with the @LABEL='CSIP'</message>
-      </error>
-      <corpusPackages>
-        <package isValid="FALSE" name="two_div_elements_with_label_Documentation">
-          <path>invalid\two_div_elements_with_label_Documentation</path>
-          <description>Package with two div-elements with @LABEL='Documentation'</description>
-        </package>
-        <package isValid="TRUE" name="minimal_IP">
-          <path>valid\minimal_IP</path>
+        <package isValid="TRUE" isImplemented="FALSE" name="minimal_IP_with_1_representation">
+          <path>valid\minimal_IP_with_1_representation</path>
           <description>Minimal IP</description>
         </package>
       </corpusPackages>

--- a/corpora/csip/metadata/structmap/CSIP95/testCase.xsd
+++ b/corpora/csip/metadata/structmap/CSIP95/testCase.xsd
@@ -70,7 +70,8 @@
   <xs:element name="requirementText">
     <xs:complexType mixed="true">
       <xs:sequence>
-        <xs:element name="nameAndLocation" type="xs:string" minOccurs="0"/>
+        <xs:element name="name" type="xs:string" minOccurs="0"/>
+        <xs:element name="location" type="xs:string" minOccurs="0"/>
         <xs:element name="description" type="xs:string" minOccurs="0"/>
         <xs:element name="cardinality" minOccurs="0">
           <xs:simpleType>
@@ -184,6 +185,21 @@
           shouldn't generate any validation messages, including WARNING or INFO
           messages. The attribute is inappropriately named but changing it would
           break too many existing test cases.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="TRUE"/>
+            <xs:enumeration value="FALSE"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="isImplemented" use="optional" default="FALSE">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+          The isImplemented attribute should be set FALSE for corpus packages that
+          are defined in the test case but not implemented as a package. The attribute
+          is optional and defaults to TRUE.
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>


### PR DESCRIPTION
CSIP95 is identical with CSIP93. This testcase's rules are therefore identical with the ones in CSIP93.
Reported to A2 here: DILCISBoard/E-ARK-CSIP#570