### PR TITLE
CSIP116 testCase.xml

### DIFF
--- a/corpora/csip/metadata/structmap/CSIP116/testCase.xml
+++ b/corpora/csip/metadata/structmap/CSIP116/testCase.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Root element for an individual test case, allows these to be wrapped into
+XML lists -->
+<testCase xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="testCase.xsd"
+  testable="TRUE">
+  <!-- Unique ID for the test case -->
+  <id specification="E-ARK CSIP" version="2.0.4" requirementId="CSIP116"/>
+  <!-- URL references to requirements for convenient lookup -->
+  <references>
+    <reference requirementId="CSIP116" URL="http://earkcsip.dilcis.eu/#CSIP116"/>
+  </references>
+  <!-- The full text of the requirement. -->
+  <requirementText>	Documentation file group reference pointer
+    mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']/fptr/@FILEID
+    A reference, by ID, to the “Documentation” file group.
+    Related to the requirements CSIP60 which describes the “Documentation” file group and CSIP65 which describes the file group identifier.
+  </requirementText>
+  <!-- Textual description of the test case, extra notes beyond the requirment text. -->
+  <description> All fileGrps with the @USE="Documentation" must also be presented in the structMap. CSIP96 and CSIP116 are intrinsically linked together and therefore is the same testcase.
+  </description>
+  <!-- List of requirments that this test case depends on in addition to the
+  main requirememt, e.g. general requirments on the form of IDs -->
+  <dependencies>
+    <dependency requirementId="CSIP96" URL="http://earkcsip.dilcis.eu/#CSIP96"></dependency>
+  </dependencies>
+  <!-- A list of the validation rules derived from the test case -->
+  <rules>
+    <rule id="1">
+      <description>All fileGrps with the @USE="Documentation" must also be presented in the structMap</description>
+      <error level="ERROR">
+        <message>All fileGrps with the @USE="Documentation" must be presented in the structMap via mets/structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']/fptr</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="fileGrp_documentation_but_missing_structMap">
+          <path>invalid\fileGrp_documentation_but_missing_structMap</path>
+          <description>A package where there is a fileGrp with @USE="Documentation" but there is no structMap [@LABEL='CSIP']/div/div[@LABEL='Documentation']/fptr/@FILEID that points to the ID of the fileGrp</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP">
+          <path>valid\minimal_IP</path>
+          <description>Minimal IP</description>
+        </package>
+      </corpusPackages>
+    </rule>
+    <rule id="2">
+      <description>A structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']/fptr must point to a fileGrp with @USE="Documentation"</description>
+      <error level="ERROR">
+        <message>The structMap[@LABEL='CSIP']/div/div[@LABEL='Documentation']/fptr points to a fileGrp that does not have @USE="Documentation"</message>
+      </error>
+      <corpusPackages>
+        <package isValid="FALSE" name="structMap_does_not_point_at_documentation">
+          <path>invalid\structMap_does_not_point_at_documentation</path>
+          <description>A package which has a documentation filepointer that points to a filegroup that does not have @USE="Documentation"</description>
+        </package>
+        <package isValid="TRUE" name="minimal_IP">
+          <path>valid\minimal_IP</path>
+          <description>Minimal IP</description>
+        </package>
+      </corpusPackages>
+    </rule>
+  </rules>
+</testCase>
+

--- a/corpora/csip/metadata/structmap/CSIP116/testCase.xsd
+++ b/corpora/csip/metadata/structmap/CSIP116/testCase.xsd
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <xs:element name="testCase">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="id"/>
+        <xs:element ref="references"/>
+        <xs:element ref="requirementText"/>
+        <xs:element ref="description"/>
+        <xs:element ref="dependencies"/>
+        <xs:element ref="rules"/>
+      </xs:sequence>
+      <xs:attribute name="testable" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="FALSE"/>
+            <xs:enumeration value="TRUE"/>
+            <xs:enumeration value="UNKNOWN"/>
+            <xs:enumeration value="PARTIAL"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="id">
+    <xs:complexType>
+      <xs:attribute name="requirementId" use="required" type="xs:NCName"/>
+      <xs:attribute name="specification" use="required"/>
+      <xs:attribute name="version" use="required" type="xs:NMTOKEN"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="references">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="reference" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="reference">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              reference (element text): Requirement text copied from the specification.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:attribute name="requirementId" use="required" type="xs:NCName">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                @requirementId: Short ID of the requirement, as defined in the specification, e.g. CSIP1, CSIPSTR5.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="URL" use="required" type="xs:anyURI">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                @URL: Direct URL to the requirement text in the specification.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="requirementText">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element name="nameAndLocation" type="xs:string" minOccurs="0"/>
+        <xs:element name="description" type="xs:string" minOccurs="0"/>
+        <xs:element name="cardinality" minOccurs="0">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="0..1"/>
+              <xs:enumeration value="0..n"/>
+              <xs:enumeration value="1..1"/>
+              <xs:enumeration value="1..n"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="level" minOccurs="0">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="MUST"/>
+              <xs:enumeration value="SHOULD"/>
+              <xs:enumeration value="MAY"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="dependencies">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="dependency" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="dependency">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+              dependency (element text): Description of the dependency.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:attribute name="requirementId" use="required" type="xs:NCName">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                @requirementId: Short ID of the requirement, as defined in the specification, e.g. CSIP1, CSIPSTR5.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="URL" use="required" type="xs:anyURI">
+            <xs:annotation>
+              <xs:documentation xml:lang="en">
+                @URL: Direct URL to the requirement text in the specification.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="rules">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element maxOccurs="unbounded" ref="rule"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="rule">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="description"/>
+        <xs:element ref="error"/>
+        <xs:element ref="corpusPackages"/>
+      </xs:sequence>
+      <xs:attribute name="id" use="required" type="xs:integer"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="error">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="message"/>
+      </xs:sequence>
+      <xs:attribute name="level" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="ERROR"/>
+            <xs:enumeration value="WARNING"/>
+            <xs:enumeration value="INFO"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="message" type="xs:string"/>
+  <xs:element name="corpusPackages">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="package" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="package">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="path"/>
+        <xs:element ref="description"/>
+      </xs:sequence>
+      <xs:attribute name="isValid" use="required">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">
+          The isValid attribute should be set TRUE for corpus packages that
+          shouldn't generate any validation messages, including WARNING or INFO
+          messages. The attribute is inappropriately named but changing it would
+          break too many existing test cases.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="TRUE"/>
+            <xs:enumeration value="FALSE"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="name" use="required" type="xs:NCName"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="path" type="xs:string"/>
+  <xs:element name="description" type="xs:string"/>
+</xs:schema>


### PR DESCRIPTION
Created a new folder and testCase.xml and -.xsd since CSIP116 was not present. CSIP96 and CSIP116 are intrinsically linked together and therefore is the same testcase as CSIP96.