### PR TITLE
FEAT: Workflow for testing corpus PRs

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           files: corpora/**
 
-      - name: Run step if any file(s) in the docs folder change
+      - name: List changed corpora files
         if: steps.changed-corpora-files.outputs.any_changed == 'true'
         run: |
-          echo "One or more files in the docs folder has changed."
+          echo "One or more files in the corpora folder have changed."
           echo "List all the files that have changed: ${{ steps.changed-corpora-files.outputs.all_changed_files }}"
   

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,29 @@
+name: PR QA
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    name: Test Changed Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Gather changed files from the corpora folder
+        id: changed-corpora-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files: corpora/**
+
+      - name: Run step if any file(s) in the docs folder change
+        if: steps.changed-corpora-files.outputs.any_changed == 'true'
+        run: |
+          echo "One or more files in the docs folder has changed."
+          echo "List all the files that have changed: ${{ steps.changed-corpora-files.outputs.all_changed_files }}"
+  


### PR DESCRIPTION
- initial workflow just to detect and list any changes to corpus files.

An example of the workflow in action can be seen here: <https://github.com/opf-labs/eark-ip-test-corpus/actions/runs/5531486888/jobs/10092244748#step:4:1> which I can use to zero in on changes. Next stop add a validation phase.